### PR TITLE
Allow origin any

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
-ruby '2.2.4'
+ruby '> 2.2.4'
 gem 'sinatra', '1.1.0'
 gem 'unicorn'
 gem 'mongo', '~> 1.12'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,3 +28,9 @@ DEPENDENCIES
   mongo (~> 1.12)
   sinatra (= 1.1.0)
   unicorn
+
+RUBY VERSION
+   ruby 2.3.3p222
+
+BUNDLED WITH
+   1.16.1

--- a/web.rb
+++ b/web.rb
@@ -27,6 +27,10 @@ class Web < Sinatra::Base
     }.to_json
   end
 
+  after do
+    response.headers['Access-Control-Allow-Origin'] = '*'
+  end
+
   get '/' do
     redirect '/index.html'
   end


### PR DESCRIPTION
I'm working on a pure JS app which talks to the PoetryDB API but it's currently being blocked by the browser.
This PR enables CORS and addresses https://github.com/thundercomb/poetrydb/issues/4
I tested it locally and it seems to work OK.