### PR TITLE
Refactor random and expand test coverage for 405 cases:

### DIFF
--- a/app/helpers/find_random.rb
+++ b/app/helpers/find_random.rb
@@ -1,0 +1,15 @@
+require 'sinatra'
+
+class Web < Sinatra::Base
+
+  def find_random()
+    settings.poetry_coll.aggregate(
+      [
+        { "$sample": { "size": 1} },
+        { "$project": { '_id' => 0, 'title' => 1, 'author' => 1, 'lines' => 1, 'linecount' => 1} }
+      ]
+    ).each { |i| @findings_data = i  }
+    @findings_data
+  end
+
+end

--- a/app/helpers/init.rb
+++ b/app/helpers/init.rb
@@ -1,6 +1,7 @@
 require_relative './format_input'
 require_relative './find_data'
 require_relative './find_list'
+require_relative './find_random'
 require_relative './response_format'
 require_relative './respond'
 require_relative './json_status'

--- a/app/routes/all.rb
+++ b/app/routes/all.rb
@@ -2,27 +2,16 @@ require 'sinatra'
 
 class Web < Sinatra::Base
 
-  get '/random' do
-    content_type :json
-
-    settings.poetry_coll.aggregate(
-      [ { "$sample": { "size": 1} } ]
-    ).each { |i| @data = i  }
-
-    # remove _id output field
-    @data.delete('_id')
-
-    respond @data
-  end
-
   get '/:key' do
     content_type :json
 
     search_key = params[:key]
-    if ['author', 'authors', 'title', 'titles'].include? search_key
+    if search_key == 'random'
+      @data = find_random()
+    elsif ['author', 'authors', 'title', 'titles'].include? search_key
       @data = find_list(search_key.chomp('s'))
     else
-      @data = json_status(
+      return json_status(
         '405',"#{search_key} list not available. Only author and title allowed."
       )
     end
@@ -34,7 +23,7 @@ class Web < Sinatra::Base
 
     if (params[:keys].split(',') - ['author', 'title', 'lines', 'linecount', 'poemcount', 'random']).length > 0
       return json_status(
-        '405',"#{params[:keys]} list not available. Only author, title, lines, linecount, and poemcount or random allowed."
+        '405',"#{params[:keys]} input field not available. Only author, title, lines, linecount, and poemcount or random allowed."
       )
     end
 
@@ -63,7 +52,7 @@ class Web < Sinatra::Base
 
     if (params[:keys].split(',') - ['author', 'title', 'lines', 'linecount', 'poemcount', 'random']).length > 0
       return json_status(
-        '405',"#{params[:keys]} list not available. Only author, title, lines, linecount, and poemcount or random allowed."
+        '405',"#{params[:keys]} input field not available. Only author, title, lines, linecount, and poemcount or random allowed."
       )
     end
 
@@ -99,7 +88,7 @@ class Web < Sinatra::Base
 
     if (params[:keys].split(',') - ['author', 'title', 'lines', 'linecount', 'poemcount', 'random']).length > 0
       return json_status(
-        '405',"#{params[:keys]} list not available. Only author, title, lines, linecount, and poemcount or random allowed."
+        '405',"#{params[:keys]} input field not available. Only author, title, lines, linecount, and poemcount or random allowed."
       )
     end
 

--- a/test/spec/poetrydb_spec.rb
+++ b/test/spec/poetrydb_spec.rb
@@ -729,17 +729,24 @@ describe('Search with invalid input fields:', {:type => :feature}) do
     expect(response.code).to be 200
   end
 
+  it('Search by invalid input field, with corresponding search field') do
+    response = TestHttp.get('/wrong/Dowson')
+    expect(response.body).to include('405')
+    expect(response.body).to include('input field not available. Only author, title, lines, linecount, and poemcount or random allowed.')
+    expect(response.code).to be 200
+  end
+
   it('Search by invalid input field; return all output fields; format by text') do
     response = TestHttp.get('/wrong/Dowson/all.text')
     expect(response.body).to include('405')
-    expect(response.body).to include('list not available. Only author, title, lines, linecount, and poemcount or random allowed.')
+    expect(response.body).to include('input field not available. Only author, title, lines, linecount, and poemcount or random allowed.')
     expect(response.code).to be 200
   end
 
   it('Search by invalid input field; return all output fields; format by json') do
     response = TestHttp.get('/wrong/Dowson/all.json')
     expect(response.body).to include('405')
-    expect(response.body).to include('list not available. Only author, title, lines, linecount, and poemcount or random allowed.')
+    expect(response.body).to include('input field not available. Only author, title, lines, linecount, and poemcount or random allowed.')
     expect(response.code).to be 200
   end
 
@@ -747,7 +754,7 @@ describe('Search with invalid input fields:', {:type => :feature}) do
     response = TestHttp.get('/wrong,linecount/Dowson;16:abs/title,lines,linecount')
     expect(response.body).not_to include('Love stays a summer night')
     expect(response.body).to include('405')
-    expect(response.body).to include('list not available. Only author, title, lines, linecount, and poemcount or random allowed.')
+    expect(response.body).to include('input field not available. Only author, title, lines, linecount, and poemcount or random allowed.')
     expect(response.code).to be 200
   end
 end
@@ -771,6 +778,22 @@ describe('Search with invalid output fields:', {:type => :feature}) do
     response = TestHttp.get('/author/Dowson/titles')
     expect(response.body).not_to include('Love stays a summer night')
     expect(response.body).to include('405')
+    expect(response.code).to be 200
+  end
+
+  it('Search by valid input fields and insufficient corresponding search fields') do
+    response = TestHttp.get('/author,title/Dowson')
+    expect(response.body).to include('405')
+    expect(response.body).to include('Comma delimited fields must have corresponding semicolon delimited search terms')
+    expect(response.body).not_to include('"title":')
+    expect(response.code).to be 200
+  end
+
+  it('Search by valid input fields and insufficient corresponding search fields; return all output fields; format as json') do
+    response = TestHttp.get('/author,title/Dowson/all.json')
+    expect(response.body).to include('405')
+    expect(response.body).to include('Comma delimited fields must have corresponding semicolon delimited search terms')
+    expect(response.body).not_to include('"title":')
     expect(response.code).to be 200
   end
 
@@ -828,4 +851,13 @@ describe('Search by invalid input field combinations:', {:type => :feature}) do
     expect(response.body).not_to include('"title":')
     expect(response.code).to be 200
   end
+
+  it('Search by valid input fields and insufficient corresponding search fields; return some output fields; format as json') do
+    response = TestHttp.get('/author,title/Dowson/title.json')
+    expect(response.body).to include('405')
+    expect(response.body).to include('Comma delimited fields must have corresponding semicolon delimited search terms')
+    expect(response.body).not_to include('"title":')
+    expect(response.code).to be 200
+  end
+
 end


### PR DESCRIPTION
- create function for find_random
- move /random to /:key like the rest
- remove redundant list wrap for one of the 405 errors
- expand test coverage for 405 errors to include all