### PR TITLE
Support linecount ranges (min / max / range)

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,7 +547,15 @@ linecount
 /linecount/<linecount>[/<output field>][,<output field>][..][.<format>]
 ```
 
-Note: linecount is always exact, and therefore the match type ```:abs``` has no effect.
+Note: a plain ```<linecount>``` is an exact match, so the match type ```:abs``` has no effect.
+
+<b>Ranges:</b> ```<linecount>``` may also be a numeric range, matched inclusively:
+
+  ```14-20```: poems with between 14 and 20 lines
+  ```-14```: poems with at most 14 lines (maximum)
+  ```14-```: poems with at least 14 lines (minimum)
+
+For example, ```/linecount/-14``` returns every poem with 14 or fewer lines, and ```/linecount,random/-14;5``` returns 5 random poems no longer than 14 lines.
 
 Format:
 ```

--- a/app/helpers/format_input.rb
+++ b/app/helpers/format_input.rb
@@ -8,9 +8,21 @@ class Web < Sinatra::Base
       if search_hash["#{key}"] == nil
         raise "405"
       elsif key == 'linecount'
-        # linecount is a string field in the database
-        # use cast to integer and back as trick to drop modifiers like ':abs'
-        search_hash["#{key}"] = search_hash["#{key}"].to_i.to_s
+        value = search_hash["#{key}"]
+        range = value.match(/\A(\d*)-(\d*)\z/)
+        if range and not (range[1].empty? and range[2].empty?)
+          # Range query: "14-20" (14..20), "-14" (<= 14), "14-" (>= 14).
+          # linecount is stored as a string, so compare numerically via $toInt.
+          bounds = []
+          bounds << { '$gte' => [{ '$toInt' => '$linecount' }, range[1].to_i] } unless range[1].empty?
+          bounds << { '$lte' => [{ '$toInt' => '$linecount' }, range[2].to_i] } unless range[2].empty?
+          search_hash.delete("#{key}")
+          (search_hash['$and'] ||= []) << { '$expr' => { '$and' => bounds } }
+        else
+          # linecount is a string field in the database
+          # use cast to integer and back as trick to drop modifiers like ':abs'
+          search_hash["#{key}"] = value.to_i.to_s
+        end
       elsif key == 'poemcount' or key == 'random'
         # poemcount should be an integer - cast drops modifiers like ':abs'
         search_hash["#{key}"] = search_hash["#{key}"].to_i

--- a/test/spec/poetrydb_spec.rb
+++ b/test/spec/poetrydb_spec.rb
@@ -290,6 +290,51 @@ describe('Linecount search:', {:type => :feature}) do
     expect(response.code).to be 200
   end
 
+  it('Search by maximum linecount (open-ended range)') do
+    response = TestHttp.get('/linecount/-9')
+    # <= 9 lines: numeric comparison, not lexical ("12"/"16" must be excluded)
+    expect(response.body).to include('Said Death to Passion')
+    expect(response.body).not_to include('Bereavement in their death to feel')
+    expect(response.body).not_to include('The Moon Maiden\'s Song')
+    expect(response.body).to include('"linecount":')
+    expect(response.code).to be 200
+  end
+
+  it('Search by minimum linecount (open-ended range)') do
+    response = TestHttp.get('/linecount/12-')
+    # >= 12 lines
+    expect(response.body).to include('Bereavement in their death to feel')
+    expect(response.body).to include('The Moon Maiden\'s Song')
+    expect(response.body).not_to include('Said Death to Passion')
+    expect(response.code).to be 200
+  end
+
+  it('Search by linecount range (both bounds)') do
+    response = TestHttp.get('/linecount/9-12')
+    # 9..12 lines inclusive
+    expect(response.body).to include('Said Death to Passion')
+    expect(response.body).to include('Bereavement in their death to feel')
+    expect(response.body).not_to include('The Moon Maiden\'s Song')
+    expect(response.code).to be 200
+  end
+
+  it('Exact linecount still matches (no range)') do
+    response = TestHttp.get('/linecount/12')
+    expect(response.body).to include('Bereavement in their death to feel')
+    expect(response.body).not_to include('The Moon Maiden\'s Song')
+    expect(response.body).not_to include('Said Death to Passion')
+    expect(response.code).to be 200
+  end
+
+  it('Combine maximum linecount with random') do
+    response = TestHttp.get('/linecount,random/-9;5')
+    # only poems with <= 9 lines are eligible for the random sample
+    expect(response.body).not_to include('Bereavement in their death to feel')
+    expect(response.body).not_to include('The Moon Maiden\'s Song')
+    expect(response.body).to include('"linecount":')
+    expect(response.code).to be 200
+  end
+
   it('Search by linecount; return some output fields; format as text') do
     response = TestHttp.get('/linecount/16/title,lines,author.text')
     expect(response.body).to include('The Moon Maiden\'s Song')


### PR DESCRIPTION
Closes #40. linecount now accepts an inclusive numeric range in addition to an exact value:

  /linecount/14-20   -> 14..20 lines
  /linecount/-14     -> at most 14 lines (the requested "maximum linecount")
  /linecount/14-     -> at least 14 lines
  /linecount/14      -> exactly 14 (unchanged)

linecount is stored as a string, so ranges compare numerically via a $toInt $expr rather than lexically (otherwise "12" would sort below "9"). Works with the random sampler too, e.g. /linecount,random/-14;5.

Adds rspec coverage for min, max, range, exact, and random-combined cases, including a case that would fail under a naive string comparison. README updated with the range syntax.