### PR TITLE
Add :author modifier to /random for author-uniform sampling

### DIFF
--- a/README.md
+++ b/README.md
@@ -799,12 +799,23 @@ Emily Dickinson
 
 <b>General Format:</b>
 ```
-/random[/<random count>][/<output field>][,<output field>][..][.<format>]
+/random[/<random count>][:author][/<output field>][,<output field>][..][.<format>]
 ```
 
 Note:
 - the random count search field is always exact, and therefore the match type ```:abs``` has no effect
 - random and poemcount cannot be used together, as both specify the number of poems to return
+- the ```:author``` modifier makes the selection uniform across authors: it returns one poem each for ```<random count>``` randomly chosen authors, so prolific poets are no more likely to appear than poets with a single poem. (By default ```/random``` is uniform across poems, so authors with more poems appear more often.) If ```<random count>``` exceeds the number of matching authors, one poem for every matching author is returned.
+
+<b>Format (uniform across authors):</b>
+```
+/random/<random count>:author
+```
+Example:
+```
+/random/3:author
+```
+This returns 3 poems, each by a different, randomly chosen author. It composes with other input fields too, eg. ```/linecount,random/-14;3:author``` returns 3 poems no longer than 14 lines, each by a different author.
 
 Format:
 ```

--- a/app/helpers/find_data.rb
+++ b/app/helpers/find_data.rb
@@ -15,8 +15,9 @@ class Web < Sinatra::Base
     elsif search_hash.keys.include?('random')
       randomcount = search_hash['random']
       search_hash.delete('random')
+      random_axis = search_hash.delete('random_axis')
 
-      @findings_data = find_random(randomcount, search_hash, output_fields)
+      @findings_data = find_random(randomcount, search_hash, output_fields, random_axis)
     # otherwise return all documents
     else
       @findings_data = settings.poetry_coll.find(

--- a/app/helpers/find_random.rb
+++ b/app/helpers/find_random.rb
@@ -2,7 +2,9 @@ require 'sinatra'
 
 class Web < Sinatra::Base
 
-  def find_random(count, search_hash = {}, output_fields = { '_id' => 0, 'title' => 1, 'author' => 1, 'lines' => 1, 'linecount' => 1 })
+  def find_random(count, search_hash = {}, output_fields = { '_id' => 0, 'title' => 1, 'author' => 1, 'lines' => 1, 'linecount' => 1 }, axis = nil)
+    return find_random_by_author(count, search_hash, output_fields) if axis == 'author'
+
     @findings_data = []
     settings.poetry_coll.aggregate(
       [
@@ -12,6 +14,19 @@ class Web < Sinatra::Base
       ]
     ).each { |i| @findings_data.append(i)  }
     @findings_data
+  end
+
+  # Uniform over authors: pick `count` distinct authors at random (from those
+  # matching search_hash) and return one random poem for each. A poet with many
+  # poems is no more likely to appear than a poet with a single poem. If count
+  # exceeds the number of matching authors, every matching author is returned.
+  def find_random_by_author(count, search_hash = {}, output_fields = { '_id' => 0, 'title' => 1, 'author' => 1, 'lines' => 1, 'linecount' => 1 })
+    authors = settings.poetry_coll.distinct('author', search_hash)
+    results = []
+    authors.sample(count).each do |author|
+      results.concat(find_random(1, search_hash.merge('author' => author), output_fields))
+    end
+    results
   end
 
 end

--- a/app/helpers/format_input.rb
+++ b/app/helpers/format_input.rb
@@ -23,7 +23,15 @@ class Web < Sinatra::Base
           # use cast to integer and back as trick to drop modifiers like ':abs'
           search_hash["#{key}"] = value.to_i.to_s
         end
-      elsif key == 'poemcount' or key == 'random'
+      elsif key == 'random'
+        value = search_hash["#{key}"]
+        # optional axis modifier: "5:author" => 5 poems, each by a random author
+        if value.end_with?(':author')
+          search_hash['random_axis'] = 'author'
+          value = value[0...-':author'.length]
+        end
+        search_hash["#{key}"] = value.to_i
+      elsif key == 'poemcount'
         # poemcount should be an integer - cast drops modifiers like ':abs'
         search_hash["#{key}"] = search_hash["#{key}"].to_i
       elsif search_hash["#{key}"][-4..-1].eql? ':abs'

--- a/test/spec/poetrydb_spec.rb
+++ b/test/spec/poetrydb_spec.rb
@@ -548,6 +548,38 @@ describe('Random search:', {:type => :feature}) do
     expect(response.code).to be 200
   end
 
+  it('Random by author returns one poem per distinct author') do
+    response = TestHttp.get('/random/10:author')
+    authors = response.parsed_response.map { |p| p['author'] }
+    # test corpus has 3 authors (Emily Dickinson has 2 poems); author-uniform
+    # collapses her to one, so exactly 3 poems come back, no author repeated
+    expect(response.parsed_response.length).to eq 3
+    expect(authors.uniq.length).to eq 3
+    expect(authors.sort).to eq ['Bob Willett', 'Emily Dickinson', 'Ernest Dowson']
+    expect(response.code).to be 200
+  end
+
+  it('Random by author with count below the number of authors') do
+    response = TestHttp.get('/random/2:author')
+    authors = response.parsed_response.map { |p| p['author'] }
+    expect(response.parsed_response.length).to eq 2
+    expect(authors.uniq.length).to eq 2   # still one poem per distinct author
+    expect(response.code).to be 200
+  end
+
+  it('Random by author composes with a linecount filter') do
+    response = TestHttp.get('/linecount,random/-9;10:author')
+    authors = response.parsed_response.map { |p| p['author'] }
+    titles = response.parsed_response.map { |p| p['title'] }
+    # <= 9 lines eligible: 'Said Death to Passion' (Dickinson, 9) and the 1-line Bob Willett poem
+    expect(response.parsed_response.length).to eq 2
+    expect(authors.sort).to eq ['Bob Willett', 'Emily Dickinson']
+    expect(titles).to include('Said Death to Passion')                 # Dickinson's only <= 9 poem
+    expect(titles).not_to include('Bereavement in their death to feel') # her 12-line poem
+    expect(response.body).not_to include('The Moon Maiden\'s Song')     # Dowson, 16 lines
+    expect(response.code).to be 200
+  end
+
 end
 
 describe('Combination search:', {:type => :feature}) do


### PR DESCRIPTION
Addresses [issue #54](https://github.com/thundercomb/poetrydb/issues/54). By default `/random` samples uniformly over poems, so prolific poets dominate results in proportion to how many poems they have. The new `:author` modifier samples uniformly over authors instead:

  `/random/5:author`            5 poems, each by a different random author
  `/linecount,random/-14;5:author`   ...composes with other input fields

It picks <count> distinct authors at random from those matching the query and returns one random poem for each, so a poet with a single poem is as likely to appear as one with hundreds. If <count> exceeds the number of matching authors, one poem per author is returned.

Implemented via the existing ":<search type>" modifier slot in the URL grammar (same mechanism as :abs), keeping the API style consistent and leaving room for future axes. Adds rspec coverage (one-per-author, sub-count, and linecount-filter composition) and documents it in the Random section of the README.