### PR TITLE
Feature/search refinements

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ The API is written in Ruby and uses Sinatra to resolve API routes. The poetry da
   ```poemcount```: ```<field data>``` is the number of poems to return  
   ```random```: ```<field data>``` is the number of random poems to return
 
+* When several ```<input field>```s are supplied but only a single ```<search term>```, the term is matched as a **union** (OR) across those fields. For example ```/title,lines/roland``` returns poems where ```roland``` appears in the title *or* the lines — the union of ```/title/roland``` and ```/lines/roland```. Union search applies to the ```author```, ```title``` and ```lines``` fields. (When the number of search terms equals the number of input fields, the fields are combined as an intersection/AND, as before.)
+
 * ```[:<search type>]``` is optional. It can be:
 
   ```:abs```: Match ```<search term>``` exactly when searching ```<input field>```  

--- a/README.md
+++ b/README.md
@@ -107,7 +107,8 @@ The API is written in Ruby and uses Sinatra to resolve API routes. The poetry da
 
 * ```[:<search type>]``` is optional. It can be:
 
-  ```:abs```: Match ```<search term>``` exactly when searching ```<input field>```  
+  ```:abs```: Match ```<search term>``` exactly (the whole field) when searching ```<input field>```  
+  ```:word```: Match ```<search term>``` as a whole word within ```<input field>``` (eg. ```eleven``` matches "eleven" but not "eleventh")  
   ```Default (empty)```: match ```<search term>``` with any part of ```<input field>``` when searching  
 
 * ```[/<output field>][,<output field>][..]``` are optional. They are a comma delimited set that can be any combination of:  

--- a/app/helpers/format_input.rb
+++ b/app/helpers/format_input.rb
@@ -3,7 +3,19 @@ require 'sinatra'
 class Web < Sinatra::Base
 
   def format_input(search_keys, search_terms)
-    search_hash = Hash[search_keys.split(',').zip(search_terms.split(';'))]
+    keys = search_keys.split(',')
+    terms = search_terms.split(';')
+
+    # Union (OR) search: several input fields but a single search term means
+    # "match this term in ANY of the given fields", eg. /title,lines/roland
+    # is the union of /title/roland and /lines/roland. Restricted to the
+    # free-text fields; the other fields have no meaningful union.
+    if keys.length > 1 and terms.length == 1
+      raise "405" unless (keys - ['author', 'title', 'lines']).empty?
+      return { '$or' => keys.map { |key| { key => search_regex(terms.first) } } }
+    end
+
+    search_hash = Hash[keys.zip(terms)]
     search_hash.keys.each do |key|
       if search_hash["#{key}"] == nil
         raise "405"
@@ -34,14 +46,23 @@ class Web < Sinatra::Base
       elsif key == 'poemcount'
         # poemcount should be an integer - cast drops modifiers like ':abs'
         search_hash["#{key}"] = search_hash["#{key}"].to_i
-      elsif search_hash["#{key}"][-4..-1].eql? ':abs'
-        search_hash["#{key}"] = search_hash["#{key}"][0..-5]
       else
-        search_value = search_hash[key].gsub("(","\\(").gsub(")","\\)")
-        search_hash["#{key}"] = /#{search_value}/i
+        search_hash["#{key}"] = search_regex(search_hash["#{key}"])
       end
     end
     search_hash
+  end
+
+  # Build the MongoDB match value for a free-text field (author/title/lines).
+  # ":abs" means an exact, whole-field match; otherwise the term matches any
+  # part of the field (case-insensitive substring).
+  def search_regex(value)
+    if value.end_with?(':abs')
+      value[0...-':abs'.length]
+    else
+      escaped = value.gsub("(", "\\(").gsub(")", "\\)")
+      /#{escaped}/i
+    end
   end
 
 end

--- a/app/helpers/format_input.rb
+++ b/app/helpers/format_input.rb
@@ -54,11 +54,15 @@ class Web < Sinatra::Base
   end
 
   # Build the MongoDB match value for a free-text field (author/title/lines).
-  # ":abs" means an exact, whole-field match; otherwise the term matches any
+  # ":abs" means an exact, whole-field match; ":word" matches the term as a
+  # whole word ("eleven" but not "eleventh"); otherwise the term matches any
   # part of the field (case-insensitive substring).
   def search_regex(value)
     if value.end_with?(':abs')
       value[0...-':abs'.length]
+    elsif value.end_with?(':word')
+      word = value[0...-':word'.length].gsub("(", "\\(").gsub(")", "\\)")
+      /\b#{word}\b/i
     else
       escaped = value.gsub("(", "\\(").gsub(")", "\\)")
       /#{escaped}/i

--- a/test/spec/poetrydb_spec.rb
+++ b/test/spec/poetrydb_spec.rb
@@ -858,19 +858,20 @@ describe('Search with invalid output fields:', {:type => :feature}) do
     expect(response.code).to be 200
   end
 
-  it('Search by valid input fields and insufficient corresponding search fields') do
+  it('Union search: one term across multiple fields matches via author') do
     response = TestHttp.get('/author,title/Dowson')
-    expect(response.body).to include('405')
-    expect(response.body).to include('Comma delimited fields must have corresponding semicolon delimited search terms')
-    expect(response.body).not_to include('"title":')
+    # author,title with a single term => union: author~Dowson OR title~Dowson
+    expect(response.body).to include('The Moon Maiden\'s Song')
+    expect(response.body).to include('Ernest Dowson')
+    expect(response.body).not_to include('Comma delimited fields must have corresponding')
     expect(response.code).to be 200
   end
 
-  it('Search by valid input fields and insufficient corresponding search fields; return all output fields; format as json') do
+  it('Union search: one term across multiple fields; return all output fields; format as json') do
     response = TestHttp.get('/author,title/Dowson/all.json')
-    expect(response.body).to include('405')
-    expect(response.body).to include('Comma delimited fields must have corresponding semicolon delimited search terms')
-    expect(response.body).not_to include('"title":')
+    expect(response.body).to include('The Moon Maiden\'s Song')
+    expect(response.body).to include('"linecount":')
+    expect(response.body).not_to include('Comma delimited fields must have corresponding')
     expect(response.code).to be 200
   end
 
@@ -929,11 +930,19 @@ describe('Search by invalid input field combinations:', {:type => :feature}) do
     expect(response.code).to be 200
   end
 
-  it('Search by valid input fields and insufficient corresponding search fields; return some output fields; format as json') do
-    response = TestHttp.get('/author,title/Dowson/title.json')
+  it('Search by valid input fields and genuinely mismatched search terms') do
+    response = TestHttp.get('/author,title,lines/Dowson;Death')
+    # 3 fields but 2 terms is a real mismatch (neither AND nor union), so still 405
     expect(response.body).to include('405')
     expect(response.body).to include('Comma delimited fields must have corresponding semicolon delimited search terms')
     expect(response.body).not_to include('"title":')
+    expect(response.code).to be 200
+  end
+
+  it('Union search rejected for non-text input fields') do
+    response = TestHttp.get('/linecount,title/5')
+    # union only applies to author/title/lines; linecount has no meaningful union
+    expect(response.body).to include('405')
     expect(response.code).to be 200
   end
 
@@ -958,6 +967,62 @@ describe('Search by invalid input field combinations:', {:type => :feature}) do
     expect(response.body).to include('"author":')
     expect(response.body).to include('"lines":')
     expect(response.body).to include('"linecount":')
+    expect(response.code).to be 200
+  end
+
+end
+
+describe('Union search (single term across multiple fields):', {:type => :feature}) do
+
+  it('Union reaches the lines field (reporter scenario: term in any field)') do
+    response = TestHttp.get('/author,title,lines/summer')
+    # 'summer' is only in the lines of "The Moon Maiden's Song"
+    expect(response.parsed_response.length).to eq 1
+    expect(response.body).to include('The Moon Maiden\'s Song')
+    expect(response.body).not_to include('Bereavement in their death to feel')
+    expect(response.code).to be 200
+  end
+
+  it('Union returns all poems matching in any field') do
+    response = TestHttp.get('/author,lines/Dickinson')
+    # author~Dickinson matches both of her poems (lines contain no "Dickinson")
+    authors = response.parsed_response.map { |p| p['author'] }
+    titles = response.parsed_response.map { |p| p['title'] }
+    expect(response.parsed_response.length).to eq 2
+    expect(authors.uniq).to eq ['Emily Dickinson']
+    expect(titles).to include('Bereavement in their death to feel')
+    expect(titles).to include('Said Death to Passion')
+    expect(response.body).not_to include('The Moon Maiden\'s Song')
+    expect(response.code).to be 200
+  end
+
+  it('Union honours the :abs modifier (exact match in any field)') do
+    # exact author "Ernest Dowson" matches; a partial "Dowson:abs" matches nothing
+    exact = TestHttp.get('/author,title/Ernest%20Dowson:abs')
+    expect(exact.body).to include('The Moon Maiden\'s Song')
+    expect(exact.code).to be 200
+
+    partial = TestHttp.get('/author,title/Dowson:abs')
+    expect(partial.body).to include('404')
+    expect(partial.body).not_to include('The Moon Maiden\'s Song')
+    expect(partial.code).to be 200
+  end
+
+  it('Intersection still works: multiple fields with matching terms are ANDed') do
+    response = TestHttp.get('/author,title/Dickinson;Passion')
+    # author~Dickinson AND title~Passion => only "Said Death to Passion"
+    expect(response.parsed_response.length).to eq 1
+    expect(response.body).to include('Said Death to Passion')
+    expect(response.body).not_to include('Bereavement in their death to feel')
+    expect(response.code).to be 200
+  end
+
+  it('Intersection across title and lines with different terms') do
+    response = TestHttp.get('/title,lines/Death;Passion')
+    # title~Death AND lines~Passion => only "Said Death to Passion"
+    expect(response.parsed_response.length).to eq 1
+    expect(response.body).to include('Said Death to Passion')
+    expect(response.body).not_to include('Bereavement in their death to feel')
     expect(response.code).to be 200
   end
 

--- a/test/spec/poetrydb_spec.rb
+++ b/test/spec/poetrydb_spec.rb
@@ -1027,3 +1027,36 @@ describe('Union search (single term across multiple fields):', {:type => :featur
   end
 
 end
+
+describe('Exact word search (:word modifier):', {:type => :feature}) do
+
+  it('Default (substring) matches a partial word') do
+    response = TestHttp.get('/lines/win')
+    # "win" appears inside "winged" in "The Moon Maiden's Song"
+    expect(response.body).to include('The Moon Maiden\'s Song')
+    expect(response.code).to be 200
+  end
+
+  it(':word excludes partial-word matches') do
+    response = TestHttp.get('/lines/win:word')
+    # no line contains "win" as a whole word, so nothing matches
+    expect(response.body).to include('404')
+    expect(response.body).not_to include('The Moon Maiden\'s Song')
+    expect(response.code).to be 200
+  end
+
+  it(':word still matches a genuine whole word') do
+    response = TestHttp.get('/lines/summer:word')
+    # "summer" appears as a whole word ("summer night")
+    expect(response.body).to include('The Moon Maiden\'s Song')
+    expect(response.code).to be 200
+  end
+
+  it(':word composes with a union search') do
+    response = TestHttp.get('/title,lines/summer:word')
+    # union across title/lines, whole-word "summer" only in the lines
+    expect(response.body).to include('The Moon Maiden\'s Song')
+    expect(response.code).to be 200
+  end
+
+end


### PR DESCRIPTION
Two small, related additions to the search grammar, each resolving a long-standing issue:

- Union (OR) search across input fields (#3): search a single term across multiple fields at once.
- `:word` whole-word matching (#57): match a term as a whole word, not a substring.

Both are opt-in and backward-compatible: no existing valid query changes behaviour.

Union search (#3)

When several input fields are supplied but only one search term is provided, the term is now matched as a union across those fields, rather than being rejected:

`/author,title,lines/William`  poems where "William" is in the author OR title OR lines
`/title,lines/roland` union of /title/roland and /lines/roland

- Restricted to the free-text fields (author, title, lines).
- Honours the `:abs` modifier within a union.
- Intersection is unchanged: when the number of terms equals the number of fields (e.g. `/title,author/Winter;Shakespeare`), fields are ANDed as before.
- This previously resulted in a 405 ("insufficient search terms"), so no existing valid query is affected. Where there are genuine mismatches (e.g. 3 fields, 2 terms) and non-text unions this would still return 405.

Whole-word matching (#57)

A new `:word` search type, alongside :abs:

`/lines/eleven:word` lines with "eleven" as a whole word, but not "eleventh"

- The default (substring) behaviour is unchanged; `:abs` (whole-field exact) is unchanged.
- Composes with union search, e.g. `/title,lines/eleven:word`.

Implementation

- Per-field text formatting is refactored into a shared search_regex helper, so both the intersection and union paths handle `:abs`/`:word` consistently.

Tests

- Full suite passes (101 examples, 0 failures) against the app in Docker.
- New coverage: union via each field, single/multiple results, :abs-in-union, intersection still ANDing, both 405 paths; and for `:word`, substring-vs-word exclusion, whole-word match, and union composition.
- The three tests that asserted the old 405 for the union shape were updated to assert the new union behaviour.

Docs

- README updated to document union search and the `:word` modifier.

Closes #3
Closes #57